### PR TITLE
Clean up .cirrus.yml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,6 +34,6 @@ task:
         image: python:latest
 
   test_indexing_script:
-    python --version
-    python -m unittest tests.test_indexing
-    uname -a
+    - python --version
+    - python -m unittest tests.test_indexing
+    - uname -a

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,7 @@ task:
           image: mojave-base
           image: high-sierra-base
       container:
+        # Use Python 2.7 for now
         image: python:latest
 
     - name: indexing test (FreeBSD)
@@ -31,9 +32,10 @@ task:
           image: freebsd-11-1-release-amd64
           image: freebsd-10-4-release-amd64
       container:
+        # Use Python 2.7 for now
         image: python:latest
 
   test_indexing_script:
+    # Print Python version for easier debugging
     - python --version
     - python -m unittest tests.test_indexing
-    - uname -a

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,44 +1,39 @@
-linux_task:
-  name: indexing test (Linux)
-  container:
-    matrix:
-      image: python:3.7
-      image: python:3.6
-      image: python:3.5
-      image: python:3.4
-  test_indexing_script:
-    python -m unittest tests.test_indexing
+task:
+  matrix:
+    - name: indexing test (Linux)
+      container:
+        matrix:
+          image: python:3.7
+          image: python:3.6
+          image: python:3.5
+          image: python:3.4
 
-windows_task:
-  name: indexing test (Windows)
-  windows_container:
-    matrix:
-      image: python:3.7
-      image: python:3.6
-      # No Python 3.4 or 3.5 for Windows
-  test_indexing_script:
-    python -m unittest tests.test_indexing
+    - name: indexing test (Windows)
+      windows_container:
+        matrix:
+          image: python:3.7
+          image: python:3.6
+          # No Python 3.4 or 3.5 for Windows
 
-macos_task:
-  name: indexing test (macOS)
-  osx_instance:
-    matrix:
-      image: mojave-base
-      image: high-sierra-base
-  container:
-    image: python:latest
-  test_indexing_script:
-    python -m unittest tests.test_indexing
+    - name: indexing test (macOS)
+      osx_instance:
+        matrix:
+          image: mojave-base
+          image: high-sierra-base
+      container:
+        image: python:latest
 
-freebsd_task:
-  name: indexing test (FreeBSD)
-  freebsd_instance:
-    matrix:
-      image: freebsd-12-0-release-amd64
-      image: freebsd-11-2-release-amd64
-      image: freebsd-11-1-release-amd64
-      image: freebsd-10-4-release-amd64
-  container:
-    image: python:latest
+    - name: indexing test (FreeBSD)
+      freebsd_instance:
+        matrix:
+          image: freebsd-12-0-release-amd64
+          image: freebsd-11-2-release-amd64
+          image: freebsd-11-1-release-amd64
+          image: freebsd-10-4-release-amd64
+      container:
+        image: python:latest
+
   test_indexing_script:
+    python --version
     python -m unittest tests.test_indexing
+    uname -a

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,8 +14,6 @@ task:
           image: python:3.7
           image: python:3.6
           # No Python 3.4 or 3.5 for Windows
-      info_script:
-        echo %OS%
 
     - name: indexing test (macOS)
       osx_instance:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,8 @@ task:
           image: python:3.7
           image: python:3.6
           # No Python 3.4 or 3.5 for Windows
+      info_script:
+        echo $Env:OS
 
     - name: indexing test (macOS)
       osx_instance:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,30 +1,43 @@
-linux_test_task:
-  name: test (Linux)
+linux_task:
+  name: indexing test (Linux)
   container:
-    image: python:latest
+    matrix:
+      image: python:3.7
+      image: python:3.6
+      image: python:3.5
+      image: python:3.4
   test_indexing_script:
     python -m unittest tests.test_indexing
 
-windows_test_task:
-  name: test (Windows)
+windows_task:
+  name: indexing test (Windows)
   windows_container:
-    image: python:latest
+    matrix:
+      image: python:3.7
+      image: python:3.6
+      # No Python 3.4 or 3.5 for Windows
   test_indexing_script:
     python -m unittest tests.test_indexing
 
-macos_test_task:
-  name: test (macOS)
+macos_task:
+  name: indexing test (macOS)
   osx_instance:
-    image: mojave-base
+    matrix:
+      image: mojave-base
+      image: high-sierra-base
   container:
     image: python:latest
   test_indexing_script:
     python -m unittest tests.test_indexing
 
-freebsd_test_task:
-  name: test (FreeBSD)
+freebsd_task:
+  name: indexing test (FreeBSD)
   freebsd_instance:
-    image: freebsd-11-2-release-amd64
+    matrix:
+      image: freebsd-12-0-release-amd64
+      image: freebsd-11-2-release-amd64
+      image: freebsd-11-1-release-amd64
+      image: freebsd-10-4-release-amd64
   container:
     image: python:latest
   test_indexing_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ task:
           image: python:3.6
           # No Python 3.4 or 3.5 for Windows
       info_script:
-        echo $Env:OS
+        echo %OS%
 
     - name: indexing test (macOS)
       osx_instance:


### PR DESCRIPTION
Use the following platforms and Python versions for Cirrus CI.

- Linux
  - Python 3.7
  - Python 3.6
  - Python 3.5
  - Python 3.4
- Windows
  - Python 3.7
  - Python 3.6
  (other Python 3 versions aren't available)
- macOS (`mojave-base`)
  - Python 2.7 (this is the default)
- macOS (`high-sierra-base`)
  - Python 2.7 (this is the default)
- FreeBSD (`freebsd-12-0-release-amd64`)
  - Python 2.7 (this is the default)
- FreeBSD (`freebsd-11-2-release-amd64`)
  - Python 2.7 (this is the default)
- FreeBSD (`freebsd-11-1-release-amd64`)
  - Python 2.7 (this is the default)
- FreeBSD (`freebsd-10-4-release-amd64`)
  - Python 2.7 (this is the default)