### PR TITLE
Add macOS and FreeBSD to continuous integration

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,8 +92,8 @@ task:
         image: python:latest
 
       freebsd_setup_script:
-        # Install Python 3
-        - pkg install python3
+        # Install Python 3 (assume yes when asked for confirmation)
+        - pkg install -y python3
         # Try bootstrapping `pip` from the standard library
         - python3 -m ensurepip --default-pip
         # Upgrade pip, setuptools and wheel

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
-task:
-  environment:
-    CODECOV_TOKEN: ENCRYPTED[fe8b1d1fb2cfca1b2949d30a7a702c7bc0e2d36f65ed94928f589fea6483ed90f4b1e93156091d4b8d96a431b0c6f426]
+environment:
+  CODECOV_TOKEN: ENCRYPTED[fe8b1d1fb2cfca1b2949d30a7a702c7bc0e2d36f65ed94928f589fea6483ed90f4b1e93156091d4b8d96a431b0c6f426]
 
+task:
   matrix:
     # Use the default name.
     # GitHub will require pull requests to pass these tests.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,8 @@ task:
           image: python:3.4
 
       linux_setup_script:
+        # Upgrade pip, setuptools and wheel
+        - python -m pip install --upgrade pip setuptools wheel
         # Use `pip install .` instead of `setup.py install`
         - python -m pip install .
 
@@ -34,6 +36,8 @@ task:
           # No Python 3.4 or 3.5 for Windows
 
       windows_setup_script:
+        # Upgrade pip, setuptools and wheel
+        - python -m pip install --upgrade pip setuptools wheel
         # Use `pip install .` instead of `setup.py install`
         - python -m pip install .
 
@@ -61,6 +65,8 @@ task:
         - brew install python3
         # Try bootstrapping `pip` from the standard library
         - python3 -m ensurepip --default-pip
+        # Upgrade pip, setuptools and wheel
+        - python3 -m pip install --upgrade pip setuptools wheel
         # Use `pip install .` instead of `setup.py install`
         - python3 -m pip install .
 
@@ -86,6 +92,8 @@ task:
         image: python:latest
 
       freebsd_setup_script:
+        # Upgrade pip, setuptools and wheel
+        - python -m pip install --upgrade pip setuptools wheel
         # Use `pip install .` instead of `setup.py install`
         - python -m pip install .
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,11 +12,41 @@ task:
           image: python:3.5
           image: python:3.4
 
+      linux_setup_script:
+        # Use `pip install .` instead of `setup.py install`
+        - python -m pip install .
+
+      linux_test_script:
+        # Print Python version for easier debugging
+        - python --version
+        - python -m pip install coverage
+        - coverage run setup.py test
+
+      linux_codecov_report_script:
+        - python -m pip install codecov
+        # Use the CODECOV_TOKEN environment variable
+        - codecov
+
     - windows_container:
         matrix:
           image: python:3.7
           image: python:3.6
           # No Python 3.4 or 3.5 for Windows
+
+      windows_setup_script:
+        # Use `pip install .` instead of `setup.py install`
+        - python -m pip install .
+
+      windows_test_script:
+        # Print Python version for easier debugging
+        - python --version
+        - python -m pip install coverage
+        - coverage run setup.py test
+
+      windows_codecov_report_script:
+        - python -m pip install codecov
+        # Use the CODECOV_TOKEN environment variable
+        - codecov
 
     - osx_instance:
         matrix:
@@ -25,6 +55,21 @@ task:
       container:
         # Use Python 2.7 for now
         image: python:latest
+
+      macos_setup_script:
+        # Use `pip install .` instead of `setup.py install`
+        - python -m pip install .
+
+      macos_test_script:
+        # Print Python version for easier debugging
+        - python --version
+        - python -m pip install coverage
+        - coverage run setup.py test
+
+      macos_codecov_report_script:
+        - python -m pip install codecov
+        # Use the CODECOV_TOKEN environment variable
+        - codecov
 
     - freebsd_instance:
         matrix:
@@ -36,17 +81,17 @@ task:
         # Use Python 2.7 for now
         image: python:latest
 
-  setup_script:
-    # Use `pip install .` instead of `setup.py install`
-    - python -m pip install .
+      freebsd_setup_script:
+        # Use `pip install .` instead of `setup.py install`
+        - python -m pip install .
 
-  test_script:
-    # Print Python version for easier debugging
-    - python --version
-    - python -m pip install coverage
-    - coverage run setup.py test
+      freebsd_test_script:
+        # Print Python version for easier debugging
+        - python --version
+        - python -m pip install coverage
+        - coverage run setup.py test
 
-  codecov_report_script:
-    - python -m pip install codecov
-    # Use the CODECOV_TOKEN environment variable
-    - codecov
+      freebsd_codecov_report_script:
+        - python -m pip install codecov
+        # Use the CODECOV_TOKEN environment variable
+        - codecov

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -91,8 +91,8 @@ task:
       freebsd_setup_script:
         # Install Python 3 (assume yes when asked for confirmation)
         - pkg install -y python3
-        # Install pip separately (needed for the FreeBSD 11.1 container)
-        - pkg install -y py3-pip
+        # Try bootstrapping `pip` from the standard library
+        - python3 -m ensurepip --default-pip
         # Upgrade pip, setuptools and wheel
         - python3 -m pip install --upgrade pip setuptools wheel
         # Use `pip install .` instead of `setup.py install`

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,18 +92,22 @@ task:
         image: python:latest
 
       freebsd_setup_script:
+        # Install Python 3
+        - pkg install python3
+        # Try bootstrapping `pip` from the standard library
+        - python3 -m ensurepip --default-pip
         # Upgrade pip, setuptools and wheel
-        - python -m pip install --upgrade pip setuptools wheel
+        - python3 -m pip install --upgrade pip setuptools wheel
         # Use `pip install .` instead of `setup.py install`
-        - python -m pip install .
+        - python3 -m pip install .
 
       freebsd_test_script:
         # Print Python version for easier debugging
-        - python --version
-        - python -m pip install coverage
+        - python3 --version
+        - python3 -m pip install coverage
         - coverage run setup.py test
 
       freebsd_codecov_report_script:
-        - python -m pip install codecov
+        - python3 -m pip install codecov
         # Use the CODECOV_TOKEN environment variable
         - codecov

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,6 @@ task:
 
       linux_codecov_report_script:
         - python3 -m pip install codecov
-        # Use the CODECOV_TOKEN environment variable
         - codecov
 
     - windows_container:
@@ -49,7 +48,6 @@ task:
 
       windows_codecov_report_script:
         - python -m pip install codecov
-        # Use the CODECOV_TOKEN environment variable
         - codecov
 
     - osx_instance:
@@ -78,7 +76,6 @@ task:
 
       macos_codecov_report_script:
         - python3 -m pip install codecov
-        # Use the CODECOV_TOKEN environment variable
         - codecov
 
     - freebsd_instance:
@@ -109,5 +106,4 @@ task:
 
       freebsd_codecov_report_script:
         - python3 -m pip install codecov
-        # Use the CODECOV_TOKEN environment variable
         - codecov

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,17 +57,21 @@ task:
         image: python:latest
 
       macos_setup_script:
+        # Install Python 3
+        - brew install python3
+        # Try bootstrapping `pip` from the standard library
+        - python3 -m ensurepip --default-pip
         # Use `pip install .` instead of `setup.py install`
-        - python -m pip install .
+        - python3 -m pip install .
 
       macos_test_script:
         # Print Python version for easier debugging
-        - python --version
-        - python -m pip install coverage
+        - python3 --version
+        - python3 -m pip install coverage
         - coverage run setup.py test
 
       macos_codecov_report_script:
-        - python -m pip install codecov
+        - python3 -m pip install codecov
         # Use the CODECOV_TOKEN environment variable
         - codecov
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,18 +14,18 @@ task:
 
       linux_setup_script:
         # Upgrade pip, setuptools and wheel
-        - python -m pip install --upgrade pip setuptools wheel
+        - python3 -m pip install --upgrade pip setuptools wheel
         # Use `pip install .` instead of `setup.py install`
-        - python -m pip install .
+        - python3 -m pip install .
 
       linux_test_script:
         # Print Python version for easier debugging
-        - python --version
-        - python -m pip install coverage
+        - python3 --version
+        - python3 -m pip install coverage
         - coverage run setup.py test
 
       linux_codecov_report_script:
-        - python -m pip install codecov
+        - python3 -m pip install codecov
         # Use the CODECOV_TOKEN environment variable
         - codecov
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -91,8 +91,8 @@ task:
       freebsd_setup_script:
         # Install Python 3 (assume yes when asked for confirmation)
         - pkg install -y python3
-        # Try bootstrapping `pip` from the standard library
-        - python3 -m ensurepip --default-pip
+        # Install pip separately (needed for the FreeBSD 11.1 container)
+        - pkg install -y py3-pip
         # Upgrade pip, setuptools and wheel
         - python3 -m pip install --upgrade pip setuptools wheel
         # Use `pip install .` instead of `setup.py install`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@
 
 # sudoku
 
-A Python implementation of a sudoku solver, using my own 6D boolean array data structure as well as my `_quick_fill` and recursion strategies.
+A Python 3 implementation of a sudoku solver, using my own 6D boolean array data structure as well as my `_quick_fill` and recursion strategies.
+
+## Prerequisites
+
+You'll need the following Python packages installed.
+- `pip`
+- `setuptools`
+- `numpy`
 
 ## Usage
 


### PR DESCRIPTION
This PR refactors `.cirrus.yml` and sets up the macOS and (most) FreeBSD containers properly. Tests are now passing.

- Separate the CI runs by platform,
- install `python3` for macOS,
- install `python3` non-interactively on FreeBSD,
- use `python3` instead of `python` on Linux, macOS, and FreeBSD, and
- run `python -m ensurepip --default-pip` on macOS and FreeBSD.

Resolves #43.