### PR TITLE
Remove the FreeBSD 10.4 and 11.1 VMs from CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,8 +82,6 @@ task:
         matrix:
           image: freebsd-12-0-release-amd64
           image: freebsd-11-2-release-amd64
-          image: freebsd-11-1-release-amd64
-          image: freebsd-10-4-release-amd64
       container:
         # Use Python 2.7 for now
         image: python:latest


### PR DESCRIPTION
Remove the FreeBSD 10.4 and 11.1 VMs from CI.

Related to issue #70.