### PR TITLE
Set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 language: python
-python:
-  - "3.7"
-  - "3.6"
-  - "3.5"
-  - "3.4"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,44 @@ python:
 
 matrix:
   include:
-    # Different Ubuntu images to run tests with
+    # Different Ubuntu images and Python versions to run tests with
+    # Enumerate all possible combinations, because the other option doesn't seem to work
     - os: linux
       dist: xenial
+      python: "3.7"
     - os: linux
       dist: trusty
+      python: "3.7"
     - os: linux
       dist: precise
+      python: "3.7"
+    - os: linux
+      dist: xenial
+      python: "3.6"
+    - os: linux
+      dist: trusty
+      python: "3.6"
+    - os: linux
+      dist: precise
+      python: "3.6"
+    - os: linux
+      dist: xenial
+      python: "3.5"
+    - os: linux
+      dist: trusty
+      python: "3.5"
+    - os: linux
+      dist: precise
+      python: "3.5"
+    - os: linux
+      dist: xenial
+      python: "3.4"
+    - os: linux
+      dist: trusty
+      python: "3.4"
+    - os: linux
+      dist: precise
+      python: "3.4"
     # To add macOS here, see https://docs.travis-ci.com/user/multi-os/#python-example-unsupported-languages
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: python
+python:
+  - "3.7"
+  - "3.6"
+  - "3.5"
+  - "3.4"
+
+matrix:
+  include:
+    # Different Ubuntu images to run tests with
+    - os: linux
+      dist: xenial
+    - os: linux
+      dist: trusty
+    - os: linux
+      dist: precise
+    # To add macOS here, see https://docs.travis-ci.com/user/multi-os/#python-example-unsupported-languages
+
+install:
+  # Print the Python version for easier debugging
+  - python --version
+  # Upgrade pip, setuptools and wheel
+  - python -m pip install --upgrade pip setuptools wheel
+  # Use `pip install .` instead of `setup.py install`
+  - python -m pip install .
+
+script:
+  # Run tests and compute code coverage
+  - python -m pip install coverage
+  - coverage run setup.py test
+  # Codecov report
+  - python -m pip install codecov
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,8 @@ matrix:
     - os: linux
       dist: xenial
       python: "3.7"
-    - os: linux
-      dist: trusty
-      python: "3.7"
-    - os: linux
-      dist: precise
-      python: "3.7"
+      # No Python 3.7 archives for Trusty or Precise
+      # See https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
     - os: linux
       dist: xenial
       python: "3.6"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Linux, macOS, FreeBSD:
   ![CirrusCI build status](https://api.cirrus-ci.com/github/pzahemszky/sudoku.svg)
 ](https://cirrus-ci.com/github/pzahemszky/sudoku)
 
+Ubuntu:
+[
+  ![Travis CI build status](https://travis-ci.com/pzahemszky/sudoku.svg?branch=master)
+](https://travis-ci.com/pzahemszky/sudoku)
+
 Windows:
 [
   ![AppVeyor build status](https://ci.appveyor.com/api/projects/status/yf8618ivmnrumk9t?svg=true)


### PR DESCRIPTION
Add Ubuntu versions to `.travis.yml`.

This PR adds Travis CI jobs for all combinations of Python 3.7, 3.6, 3.5, 3.4 and Ubuntu 16.04 (Xenial), 14.04 (Trusty), 12.04 (Precise), except Python 3.7 on Trusty and Precise.

Closes #48.